### PR TITLE
feat(listen-mode): Add progressive hints for incorrect answers

### DIFF
--- a/modes/listen_and_reveal_mode.py
+++ b/modes/listen_and_reveal_mode.py
@@ -89,16 +89,19 @@ class ListenAndRevealMode(ChordModeBase):
                         played_chord_info = f"{recognized_name} ({recognized_inversion})" if recognized_name else "Accord non reconnu"
                         feedback_text = Text.from_markup(f"[bold red]Incorrect.[/bold red] Vous avez joué : {played_chord_info}")
 
-                        if incorrect_attempts >= 3:
-                            tonic_name = get_note_name(sorted(list(self.current_chord_notes))[0])
-                            feedback_text.append(Text.from_markup(f"\nIndice : La tonique est [bold cyan]{tonic_name}[/bold cyan]."))
-
                         if incorrect_attempts >= 7:
-                            revealed_type = get_chord_type_from_name(self.current_chord_name)
                             feedback_text.append(Text.from_markup(f"\n[bold magenta]La réponse était : {self.current_chord_name}[/bold magenta]"))
                             live.update(Panel(feedback_text, title="Réponse", border_style="magenta"), refresh=True)
                             time.sleep(2.5)
                             break
+
+                        if incorrect_attempts >= 3:
+                            tonic_name = get_note_name(sorted(list(self.current_chord_notes))[0])
+                            feedback_text.append(Text.from_markup(f"\nIndice : La tonique est [bold cyan]{tonic_name}[/bold cyan]."))
+
+                        if incorrect_attempts >= 5:
+                            chord_type = get_chord_type_from_name(self.current_chord_name)
+                            feedback_text.append(Text.from_markup(f"\nIndice : Le type d'accord est [bold yellow]{chord_type}[/bold yellow]."))
 
                 self.session_total_count += 1
                 if self.exit_flag: break


### PR DESCRIPTION
Implements a progressive hint system in the 'Listen and Guess' mode based on the number of incorrect attempts.

- After 3 incorrect attempts, the tonic of the chord is revealed.
- After 5 incorrect attempts, the chord type (e.g., major, minor) is also revealed.
- The round still ends after 7 incorrect attempts, at which point the full answer is shown.